### PR TITLE
规则修改

### DIFF
--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -18,11 +18,11 @@
       "packName": "com.xuncorp.suvine.music",
       "rules": [
         {
-          "startVersionCode": 0,
-          "endVersionCode": 0,
+          "startVersionCode": 2023070801,
+          "endVersionCode": 2147483647,
           "excludeVersions": [],
-          "apiVersion": 0,
-          "useApi": false,
+          "apiVersion": 4,
+          "useApi": true,
           "getLyricType": 0,
           "remarks": ""
         }
@@ -61,7 +61,7 @@
       "rules": [
         {
           "startVersionCode": 1266,
-          "endVersionCode": 1287,
+          "endVersionCode": 1299,
           "excludeVersions": [],
           "apiVersion": 0,
           "useApi": false,

--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -18,7 +18,7 @@
       "packName": "com.xuncorp.suvine.music",
       "rules": [
         {
-          "startVersionCode": 2023070801,
+          "startVersionCode": 2023072601,
           "endVersionCode": 2147483647,
           "excludeVersions": [],
           "apiVersion": 4,


### PR DESCRIPTION
添加 糖醋音乐 适配范围，从2023072601起
修改 Apple Music 适配范围到1299（4.3.0-beta）