### PR TITLE
Add LyricGetterExt Support

### DIFF
--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -322,7 +322,7 @@
           "startVersionCode": 0,
           "endVersionCode": 2147483647,
           "excludeVersions": [],
-          "apiVersion": 4,
+          "apiVersion": 5,
           "useApi": true,
           "getLyricType": 0,
           "remarks": ""

--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -313,6 +313,21 @@
           "remarks": ""
         }
       ]
+    },
+    {
+      "packageName": "statusbar.finder",
+      "name": "LyricsGetter Ext",
+      "rules": [
+        {
+          "startVersionCode": 0,
+          "endVersionCode": 2147483647,
+          "excludeVersions": [],
+          "apiVersion": 4,
+          "useApi": true,
+          "getLyricType": 0,
+          "remarks": ""
+        }
+      ]
     }
   ],
   "appRulesVersion": 3,

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -22,5 +22,6 @@
         <item>com.xuncorp.suvine.music</item>
         <item>com.caij.puremusic</item>
         <item>com.xuncorp.qinalt.music</item>
+        <item>statusbar.finder</item>
     </array>
 </resources>


### PR DESCRIPTION
[LyricsGetterExt](https://github.com/VictorModi/LyricsGetterExt)
Use MediaController to get the media information, then get the relevant lyrics through the information, and finally push to Lyrics-Getter, mainly used to support Spotify.
This Pull request is only for adding LyricsGetterExt to the Xposed Scope of Lyrics-Getter.

通过 MediaController 获取媒体信息再通过网络搜索获取歌词推送至 Lyrics-Getter 。
主要用于支持Spotify。
本次pr仅用于将 LyricsGetterExt 添加至 Lyrics-Getter 的 "推荐应用" 列表。