### PR TITLE
[Bugfix]拦截QQLite的占位歌词

### DIFF
--- a/app/src/main/java/cn/lyric/getter/tool/HookTools.kt
+++ b/app/src/main/java/cn/lyric/getter/tool/HookTools.kt
@@ -179,6 +179,7 @@ object HookTools {
             remoteControlManager.methodFinder().first { name == "updataMetaData" }.createHook {
                 before {
                     val lyric = if (it.args[1].isNull()) return@before else it.args[1].toString()
+                    if ("NEED_NOT_UPDATE_TITLE" == lyric) return@before
                     sendLyric(context, lyric)
                 }
             }


### PR DESCRIPTION
Bug:
    MIUI的音乐使用该插件的时候，在不播放音乐的情况下，依然显示
NEED_NOT_UPDATE_TITLE，影响使用体验。

问题根因:
    NEED_NOT_UPDATE_TITLE在RemoteControlManager中是个常量字符串，
分析来看，应当是占位字符串，不应当作为歌词看待。

修复方案：
    拦截这个字符串，因为其已经是个常量了，没有意义。