### PR TITLE
Update Lyrics Getter Ext apiVersion to app_rules.json

### DIFF
--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -320,9 +320,18 @@
       "rules": [
         {
           "startVersionCode": 0,
-          "endVersionCode": 2147483647,
+          "endVersionCode": 6,
           "excludeVersions": [],
           "apiVersion": 5,
+          "useApi": true,
+          "getLyricType": 0,
+          "remarks": ""
+        },
+        {
+          "startVersionCode": 7,
+          "endVersionCode": 2147483647,
+          "excludeVersions": [],
+          "apiVersion": 6,
           "useApi": true,
           "getLyricType": 0,
           "remarks": ""


### PR DESCRIPTION
由于 Lyrics Getter API 更新，所以现在更新 Lyrics Getter Ext 的规则以适配新的  Lyrics Getter API 。