### PR TITLE
Support KDE Connect

### DIFF
--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -510,6 +510,6 @@
       ]
     }
   ],
-  "appRulesVersion": 8,
+  "appRulesVersion": 9,
   "version": 6
 }

--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -493,6 +493,21 @@
           "remarks": ""
         }
       ]
+    },
+    {
+      "packageName": "org.kde.kdeconnect_tp",
+      "name": "KDE Connect",
+      "rules": [
+        {
+          "startVersionCode": 12000,
+          "endVersionCode": 2147483647,
+          "excludeVersions": [],
+          "apiVersion": 0,
+          "useApi": false,
+          "getLyricType": 1,
+          "remarks": ""
+        }
+      ]
     }
   ],
   "appRulesVersion": 8,

--- a/app/src/main/java/cn/lyric/getter/hook/MainHook.kt
+++ b/app/src/main/java/cn/lyric/getter/hook/MainHook.kt
@@ -9,6 +9,7 @@ import cn.lyric.getter.hook.app.Bodian
 import cn.lyric.getter.hook.app.Flamingo
 import cn.lyric.getter.hook.app.Kugou
 import cn.lyric.getter.hook.app.Kuwo
+import cn.lyric.getter.hook.app.Kde
 import cn.lyric.getter.hook.app.LMusic
 import cn.lyric.getter.hook.app.Luna
 import cn.lyric.getter.hook.app.Meizu
@@ -60,6 +61,7 @@ class MainHook : IXposedHookLoadPackage, IXposedHookZygoteInit {
             "fun.upup.musicfree" -> initHooks(MusicFree)
             "com.mimicry.mymusic" -> initHooks(Mimicry)
             "yos.music.player" -> initHooks(Flamingo)
+            "org.kde.kdeconnect_tp" -> initHooks(Kde)
             else -> initHooks(Api)
         }
     }

--- a/app/src/main/java/cn/lyric/getter/hook/app/Kde.kt
+++ b/app/src/main/java/cn/lyric/getter/hook/app/Kde.kt
@@ -1,0 +1,14 @@
+package cn.lyric.getter.hook.app
+
+import cn.lyric.getter.hook.BaseHook
+import cn.lyric.getter.tool.HookTools
+import cn.lyric.getter.tool.HookTools.mediaMetadataCompatLyric
+
+object Kde : BaseHook() {
+    override fun init() {
+        super.init()
+        HookTools.getApplication {
+            mediaMetadataCompatLyric(it.classLoader)
+            }
+        }
+    }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -30,5 +30,6 @@
         <item>fun.upup.musicfree</item>
         <item>com.mimicry.mymusic</item>
         <item>yos.music.player</item>
+        <item>org.kde.kdeconnect_tp</item>
     </array>
 </resources>


### PR DESCRIPTION
跨设备同步歌词，但仅限于把歌词设置为媒体播放控件的标题，安卓设备打开蓝牙歌词即可

效果图

![Screenshot_20240614-082722](https://github.com/xiaowine/Lyric-Getter/assets/36808766/4199a839-857a-45b8-8eb5-499308a76c7b)
