### PR TITLE
修复酷狗版本判断导致概念版4.0.0无法使用问题，更新规格文件

### DIFF
--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -148,7 +148,7 @@
     },
     {
       "packageName": "com.kugou.android.lite",
-      "name": "酷狗音乐概念版",
+      "name": "酷狗概念版",
       "rules": [
         {
           "startVersionCode": 10545,
@@ -160,13 +160,13 @@
           "remarks": ""
         },
         {
-          "startVersionCode": 10545,
+          "startVersionCode": 10649,
           "endVersionCode": 2147483647,
           "excludeVersions": [],
           "apiVersion": 0,
           "useApi": false,
-          "getLyricType": 1,
-          "remarks": ""
+          "getLyricType": 0,
+          "remarks": "需在APP设置中打开状态栏歌词开关"
         }
       ]
     },
@@ -220,7 +220,7 @@
           "apiVersion": 0,
           "useApi": false,
           "getLyricType": 0,
-          "remarks": ""
+          "remarks": "需在APP设置中打开状态栏歌词开关"
         }
       ]
     },

--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -529,5 +529,5 @@
     }
   ],
   "appRulesVersion": 11,
-  "version": 7
+  "version": 8
 }

--- a/app/src/main/assets/app_rules.json
+++ b/app/src/main/assets/app_rules.json
@@ -528,6 +528,6 @@
       ]
     }
   ],
-  "appRulesVersion": 10,
+  "appRulesVersion": 11,
   "version": 7
 }

--- a/app/src/main/kotlin/cn/lyric/getter/hook/app/Kugou.kt
+++ b/app/src/main/kotlin/cn/lyric/getter/hook/app/Kugou.kt
@@ -27,7 +27,7 @@ object Kugou : BaseHook() {
                             hookLocalBroadcast("android.support.v4.content.LocalBroadcastManager")
                         }
 
-                        verCode <= 999999 -> {
+                        else -> {
                             HookTools.MockFlyme().mock()
                             hookLocalBroadcast("androidx.localbroadcastmanager.content.LocalBroadcastManager")
                         }
@@ -42,7 +42,7 @@ object Kugou : BaseHook() {
                             hookLocalBroadcast("android.support.v4.content.LocalBroadcastManager")
                         }
 
-                        verCode > 11001 -> {
+                        else -> {
                             HookTools.MockFlyme().mock()
                             hookLocalBroadcast("androidx.localbroadcastmanager.content.LocalBroadcastManager")
                         }


### PR DESCRIPTION
本来还想修一下闪退问题，但是堆栈里定位不到问题代码在哪

主要都是规则Fragment刷新规则的问题，线程完成的时候fragment可能已经销毁了。
闪退1 Parcel: unknown type for value AppInfos...
闪退2 Fragment AppRulesFragment ... not attached to a context.
闪退3 读取binding空指针

调的过程中还遇到主界面提示激活失败的问题，查了日志是DSP.init的时候报错java.lang.SecurityException: MODE_WORLD_READABLE no longer supported，commit记录里排查半天最后发现versionCode不能是22，改成21或者23就正常，关键之前是22也正常，不知道什么原因


算了，hook正常就行，反正平时也不打开