### PR TITLE
修复酷狗概念版偶现崩溃问题

### DIFF
--- a/app/src/main/kotlin/cn/lyric/getter/hook/app/Kugou.kt
+++ b/app/src/main/kotlin/cn/lyric/getter/hook/app/Kugou.kt
@@ -102,7 +102,7 @@ object Kugou : BaseHook() {
             .createHook {
                 after {
                     val mServiceName = XposedHelpers.getObjectField(it.thisObject, "serviceName")
-                    if (mServiceName == Context.WIFI_SERVICE && it.throwable != null) { // 当由错误抛出时才使用替代方法，防止软件崩溃。
+                    if (mServiceName == Context.WIFI_SERVICE && it.throwable != null) { // 当有错误抛出时才使用替代方法，防止软件崩溃。
                         it.throwable = null
                         it.result = null
                     }


### PR DESCRIPTION
很神奇的崩溃点，启用模块会导致软件在未知时间崩溃数次后恢复正常。
已经测试关闭模块不会出现这种情况。

根据我的测试：
启用模块会导致其获取到本应当因崩溃而无法获取的字段。
随后走注入系统服务的逻辑，但在逻辑处有一处会导致崩溃的点，走到这里就崩溃。
但是为什么连续崩溃重开几次就恢复正常了我就不太清楚了，看日志似乎还是有崩溃的。

环境：4.0.21 版本 k50 hyperOS1 上。