### PR TITLE
删除导致酷狗概念版旧版本无法获取歌词的进程判断

### DIFF
--- a/app/src/main/kotlin/cn/lyric/getter/hook/app/Kugou.kt
+++ b/app/src/main/kotlin/cn/lyric/getter/hook/app/Kugou.kt
@@ -25,7 +25,6 @@ object Kugou : BaseHook() {
             val verCode: Int = app.packageManager?.getPackageInfo(app.packageName, 0)?.getVersionCode() ?: 0
             when (app.packageName) {
                 "com.kugou.android" -> {
-                    if (getProcessName(app) == "com.kugou.android.support") return@getApplication
                     when {
                         verCode <= 10000 -> hookCarLyric()
                         verCode <= 12009 -> {

--- a/app/src/main/kotlin/cn/lyric/getter/hook/app/Kugou.kt
+++ b/app/src/main/kotlin/cn/lyric/getter/hook/app/Kugou.kt
@@ -42,7 +42,6 @@ object Kugou : BaseHook() {
                 }
 
                 "com.kugou.android.lite" -> {
-                    if (getProcessName(app) == "com.kugou.android.lite.support") return@getApplication
                     when {
                         verCode <= 10648 -> hookCarLyric()
                         verCode <= 10935 -> {


### PR DESCRIPTION
旧版歌词在 com.kugou.android.lite.support 进程